### PR TITLE
Travis CI: Fix broken .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,15 @@ matrix:
     - python: "3.7"
   allow_failures:
     - python: "3.7"
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 cache: pip
 addons:
   apt:
     packages:
       - libhdf5-serial-dev
 env:
-  - LC_ALL="en_US.UTF-8"
-  - CP_MYSQL_TEST_HOST="127.0.0.1"
-  - CP_MYSQL_TEST_USER="root"
-  - CP_MYSQL_TEST_PASSWORD=""
+  - LC_ALL="en_US.UTF-8" CP_MYSQL_TEST_HOST="127.0.0.1" CP_MYSQL_TEST_USER="root" CP_MYSQL_TEST_PASSWORD=""
 install:
   - pip install --upgrade pip
   - pip install --upgrade cython joblib numpy scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - pip install --upgrade cython joblib numpy scipy
   - pip install --editable git+https://github.com/CellProfiler/CellProfiler.git#egg=CellProfiler
   - pip freeze
-script: make test
+script: travis_wait 30 make test
 after_script: make clean
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ python:
 matrix:
   include:
     - python: "3.7"
-  allow_failures:
-    - python: "3.7"
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+allow_failures:
+     - python: "3.7"
 cache: pip
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
-python:
-  - "2.7"
 matrix:
   include:
-    - python: "3.7"
+    - python: 2.7
+    - python: 3.6.3
+    - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
       sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 allow_failures:
-     - python: "3.7"
+     - python: 3.7
 cache: pip
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,28 @@
+language: python
+python:
+  - "2.7"
+matrix:
+  include:
+    - python: "3.7"
+  allow_failures:
+    - python: "3.7"
+cache: pip
 addons:
   apt:
     packages:
       - libhdf5-serial-dev
-      - python-pip
-  apt: true
-  directories: $HOME/.cache/pip
-dist: trusty
-after_script: make clean
 env:
-  - LC_ALL="en_US.UTF-8" CP_MYSQL_TEST_HOST="127.0.0.1" CP_MYSQL_TEST_USER="root" CP_MYSQL_TEST_PASSWORD=""
+  - LC_ALL="en_US.UTF-8"
+  - CP_MYSQL_TEST_HOST="127.0.0.1"
+  - CP_MYSQL_TEST_USER="root"
+  - CP_MYSQL_TEST_PASSWORD=""
 install:
   - pip install --upgrade pip
-  - pip install --upgrade cython
-  - pip install --upgrade joblib
-  - pip install --upgrade numpy
-  - pip install --upgrade scipy
+  - pip install --upgrade cython joblib numpy scipy
   - pip install --editable git+https://github.com/CellProfiler/CellProfiler.git#egg=CellProfiler
   - pip freeze
-language: python
+script: make test
+after_script: make clean
 notifications:
   email: false
   slack:
@@ -25,7 +30,3 @@ notifications:
     on_pull_requests: false
     on_success: never
     secure: TkDoDwLYouHg8YeUm0JaB4YD1LEbji3cs7FIQAedZKL7ELAKVwC4zKuJdS9Ri5mKvkD6FsLxUKiZWR7lCRRc8xZlJtD3jleKa+WMsQHYenAgJgtaaf2pE3AHN42g8StujCImynFDCEEu3lKd3EI9/sLuwe7gmwZjQ6hGugBYBShWUzhQzfwB3D3PBcrztCeL7RvUjJt/h4KCr0sU328927tvqVxkRUPZsJbPUwcVYCImdjnv9Uf5pTIp+PFkyxV5x16evKylX3GnN0GXLF//zR47e2h+DRdhX9WiMnM9pof7O3xZSbXorw3vdxV51IAocILqR2pB3yMxpkI4PmSziMNJCtl+4I5xpKSb7X7K4qpm8ztCez9QtTEOLg5DgvrC+okoS7M8JpxOFuvv4PfyXLvKOHzd74l82XN0q4d7ezVuT04HP/wTl83KfbtKOlRvlBy2SkfFsCzaLyZECvf02Gf7jS4OniIP47wUz3L8U9w6x23y5K8cUMQhVzOO8mNw4bSQgtd2Kn2ZqEmWY+WdO79jjfTbWRrennBtFdNt3LvCol0IkcXNDt3DFMsqG823bjgQuDs2lU5mAQe4RHbmVxlKd/pqVIlztyDhard6apyUa779r+XJVDVlw+xYZQKK1Ere754QPQ2ScRDyv2oOnpdHc3b8SUVHVzhi3daIShA=
-python: 2.7
-script:
-  - make test
-sudo: false


### PR DESCRIPTION
Your review please @AetherUnbound @mcquin
Sorting .travis.yml by the YAML keys does not help readability.  Some things (like __language__ and __env__) happen at a global level before the testing starts.  Other things get executed in the testing and should come in the proper order: __before_script__ —> __script__ —> __after_script__.  Sorting alphabetically makes all that difficult to track.

PRs that fail the tests rarely should be merged.